### PR TITLE
add sriov 5g core networks

### DIFF
--- a/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/00-fec3-sriov-node-policy.yaml
+++ b/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/00-fec3-sriov-node-policy.yaml
@@ -1,88 +1,109 @@
----
+###############################################################################
+# SR-IOV netdevice for all 4G/5G core networks
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: core-network-devices
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: core_sriov_netdevice
+  nodeSelector:
+    feature.node.kubernetes.io/open5gs: "true"
+  deviceType: netdevice
+  priority: 10
+  #mtu: 1500
+  numVfs: 10
+  nicSelector:
+    vendor: "8086"
+    deviceID: "159b"
+    pfNames:
+      - ens4f0#0-9
+#
+#---
 ###############################################################################
 # specific resourceName for it (eg. sriov-netdevice-smci00)
-apiVersion: sriovnetwork.openshift.io/v1
-kind: SriovNetworkNodePolicy
-metadata:
-  name: fec3-sriov-netdevice-dell03
-  namespace: openshift-sriov-network-operator
-spec:
-  resourceName: vran_netdevice
-  nodeSelector:
-    ran.openshift.io/sriov: ""
-    ran.openshift.io/fec3-sriov-netdevice-dell03: ""
-  deviceType: netdevice
-  priority: 10
+#apiVersion: sriovnetwork.openshift.io/v1
+#kind: SriovNetworkNodePolicy
+#metadata:
+#  name: fec3-sriov-netdevice-dell03
+#  namespace: openshift-sriov-network-operator
+#spec:
+#  resourceName: vran_netdevice
+#  nodeSelector:
+#    ran.openshift.io/sriov: ""
+#    ran.openshift.io/fec3-sriov-netdevice-dell03: ""
+#  deviceType: netdevice
+#  priority: 10
   #mtu: 1500
-  numVfs: 10
-  nicSelector:
-    vendor: "8086"
-    deviceID: "159b"
-    pfNames:
-      - ens4f0#0-3
----
+#  numVfs: 10
+#  nicSelector:
+#    vendor: "8086"
+#    deviceID: "159b"
+#    pfNames:
+#      - ens4f0#0-3
+#---
 ###############################################################################
 # specific resourceName for it (eg. sriov-vfio-smci00)
-apiVersion: sriovnetwork.openshift.io/v1
-kind: SriovNetworkNodePolicy
-metadata:
-  name: fec3-sriov-vfio-ar-dell03
-  namespace: openshift-sriov-network-operator
-spec:
-  resourceName: vran_vfio_ar
-  nodeSelector:
-    ran.openshift.io/sriov: ""
-    ran.openshift.io/fec3-sriov-vfio-dell03: ""
-  deviceType: vfio-pci
-  priority: 10
+#apiVersion: sriovnetwork.openshift.io/v1
+#kind: SriovNetworkNodePolicy
+#metadata:
+#  name: fec3-sriov-vfio-ar-dell03
+#  namespace: openshift-sriov-network-operator
+#spec:
+#  resourceName: vran_vfio_ar
+#  nodeSelector:
+#    ran.openshift.io/sriov: ""
+#    ran.openshift.io/fec3-sriov-vfio-dell03: ""
+#  deviceType: vfio-pci
+#  priority: 10
   #mtu: 1500
-  numVfs: 10
-  nicSelector:
-    vendor: "8086"
-    deviceID: "159b"
-    pfNames:
-      - ens4f0#4-5
----
+#  numVfs: 10
+#  nicSelector:
+#    vendor: "8086"
+#    deviceID: "159b"
+#    pfNames:
+#      - ens4f0#4-5
+#---
 ###############################################################################
 # specific resourceName for it (eg. sriov-vfio-smci00)
-apiVersion: sriovnetwork.openshift.io/v1
-kind: SriovNetworkNodePolicy
-metadata:
-  name: fec3-sriov-vfio-dell03
-  namespace: openshift-sriov-network-operator
-spec:
-  resourceName: vran_vfio
-  nodeSelector:
-    ran.openshift.io/sriov: ""
-    ran.openshift.io/fec3-sriov-vfio-dell03: ""
-  deviceType: vfio-pci
-  priority: 10
+#apiVersion: sriovnetwork.openshift.io/v1
+#kind: SriovNetworkNodePolicy
+#metadata:
+#  name: fec3-sriov-vfio-dell03
+#  namespace: openshift-sriov-network-operator
+#spec:
+#  resourceName: vran_vfio
+#  nodeSelector:
+#    ran.openshift.io/sriov: ""
+#    ran.openshift.io/fec3-sriov-vfio-dell03: ""
+#  deviceType: vfio-pci
+#  priority: 10
   #mtu: 1500
-  numVfs: 10
-  nicSelector:
-    vendor: "8086"
-    deviceID: "159b"
-    pfNames:
-      - ens4f0#6-7
----
+#  numVfs: 10
+#  nicSelector:
+#    vendor: "8086"
+#    deviceID: "159b"
+#    pfNames:
+#      - ens4f0#6-7
+#---
 ###############################################################################
 # specific resourceName for it (eg. sriov-netdevice-fh-smci00)
-apiVersion: sriovnetwork.openshift.io/v1
-kind: SriovNetworkNodePolicy
-metadata:
-  name: fec3-sriov-netdevice-fh-dell03
-  namespace: openshift-sriov-network-operator
-spec:
-  resourceName: vran_netdevice_fh
-  nodeSelector:
-    ran.openshift.io/sriov: ""
-    ran.openshift.io/fec3-sriov-netdevice-fh-dell03: ""
-  deviceType: netdevice
-  priority: 10
+#apiVersion: sriovnetwork.openshift.io/v1
+#kind: SriovNetworkNodePolicy
+#metadata:
+#  name: fec3-sriov-netdevice-fh-dell03
+#  namespace: openshift-sriov-network-operator
+#spec:
+#  resourceName: vran_netdevice_fh
+#  nodeSelector:
+#    ran.openshift.io/sriov: ""
+#    ran.openshift.io/fec3-sriov-netdevice-fh-dell03: ""
+#  deviceType: netdevice
+#  priority: 10
   #mtu: 1500
-  numVfs: 10
-  nicSelector:
-    vendor: "8086"
-    deviceID: "159b"
-    pfNames:
-      - ens4f0#8-9
+#  numVfs: 10
+#  nicSelector:
+#    vendor: "8086"
+#    deviceID: "159b"
+#    pfNames:
+#      - ens4f0#8-9

--- a/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-bh-n2.yaml
+++ b/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-bh-n2.yaml
@@ -1,0 +1,30 @@
+---
+###############################################################################
+# SR-IOV Network Definition for the NS of the workload
+#  N2-bh + vlan 823 + core_sriov_netdevice
+###############################################################################
+# NS = open5gs-core
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: n2bh
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: core_sriov_netdevice
+  networkNamespace: open5gs-core
+  vlan: 823
+  ipam: |-
+    {
+      "type": "static",
+      "addresses": [
+        {
+          "address": "10.28.3.8/24",
+          "gateway": "10.28.3.1"
+        },
+        {
+          "address": "fd00:6:6:823::8/64",
+          "gateway": "fd00:6:6:823::1"
+        }
+      ]
+    }
+  linkState: auto

--- a/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-bh-n3.yaml
+++ b/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-bh-n3.yaml
@@ -1,0 +1,30 @@
+---
+###############################################################################
+# SR-IOV Network Definition for the NS of the workload
+#  N3-bh + vlan 824 + core_sriov_netdevice
+###############################################################################
+# NS = open5gs-core
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: n3bh
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: core_sriov_netdevice
+  networkNamespace: open5gs-core
+  vlan: 824
+  ipam: |-
+    {
+      "type": "static",
+      "addresses": [
+        {
+          "address": "10.28.4.8/24",
+          "gateway": "10.28.4.1"
+        },
+        {
+          "address": "fd00:6:6:824::8/64",
+          "gateway": "fd00:6:6:824::1"
+        }
+      ]
+    }
+  linkState: auto

--- a/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-bh-s1c.yaml
+++ b/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-bh-s1c.yaml
@@ -1,0 +1,30 @@
+---
+###############################################################################
+# SR-IOV Network Definition for the NS of the workload
+#  s1c-bh + vlan 825 + core_sriov_netdevice
+###############################################################################
+# NS = open5gs-core
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: s1cbh
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: core_sriov_netdevice
+  networkNamespace: open5gs-core
+  vlan: 825
+  ipam: |-
+    {
+      "type": "static",
+      "addresses": [
+        {
+          "address": "10.28.5.8/24",
+          "gateway": "10.28.5.1"
+        },
+        {
+          "address": "fd00:6:6:825::8/64",
+          "gateway": "fd00:6:6:825::1"
+        }
+      ]
+    }
+  linkState: auto

--- a/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-bh-s1u.yaml
+++ b/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-bh-s1u.yaml
@@ -1,0 +1,30 @@
+---
+###############################################################################
+# SR-IOV Network Definition for the NS of the workload
+#  s1u-bh + vlan 826 + core_sriov_netdevice
+###############################################################################
+# NS = open5gs-core
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: s1ubh
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: core_sriov_netdevice
+  networkNamespace: open5gs-core
+  vlan: 826
+  ipam: |-
+    {
+      "type": "static",
+      "addresses": [
+        {
+          "address": "10.28.6.8/24",
+          "gateway": "10.28.6.1"
+        },
+        {
+          "address": "fd00:6:6:826::8/64",
+          "gateway": "fd00:6:6:826::1"
+        }
+      ]
+    }
+  linkState: auto

--- a/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-wan-n6.yaml
+++ b/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/01-sriov-wan-n6.yaml
@@ -1,0 +1,30 @@
+---
+###############################################################################
+# SR-IOV Network Definition for the NS of the workload
+#  n6 + vlan 901 + core_sriov_netdevice
+###############################################################################
+#
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: n6wan
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: core_sriov_netdevice
+  networkNamespace: open5gs-core
+  vlan: 821
+  ipam: |-
+    {
+      "type": "static",
+      "addresses": [
+        {
+          "address": "10.28.1.8/24",
+          "gateway": "10.28.1.1"
+        },
+        {
+          "address": "fd00:6:6:821::8/64",
+          "gateway": "fd00:6:6:821::1"
+        }
+      ]
+    }
+  linkState: auto

--- a/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/kustomization.yml
+++ b/rhocp-clusters/tesla.cars.lab/sites/fec3-dell03/02-configs/kustomization.yml
@@ -10,11 +10,17 @@ resources:
   # SRIOV Configs
   #- 00-fec3-sriov-namespace.yaml
   - 00-fec3-sriov-node-policy.yaml
-  - 01-fec3-sriov-vran-mgmt.yaml
-  - 01-fec3-sriov-vran-mh.yaml
-  - 01-fec3-sriov-vran-fh.yaml
-  - 01-fec3-sriov-vran-ar.yaml
-  - 01-fec3-sriov-vran-mp.yaml
+  # 5G Core SRIOV nets
+  - 01-sriov-bh-n2.yaml
+  - 01-sriov-bh-n3.yaml
+  - 01-sriov-bh-s1c.yaml
+  - 01-sriov-bh-s1u.yaml
+  - 01-sriov-wan-n6.yaml
+    #- 01-fec3-sriov-vran-mgmt.yaml
+    #- 01-fec3-sriov-vran-mh.yaml
+    #- 01-fec3-sriov-vran-fh.yaml
+    #- 01-fec3-sriov-vran-ar.yaml
+    #- 01-fec3-sriov-vran-mp.yaml
   # Storage Configs
   # - 02-fec3-local-storage-dell03.yaml
   # PTP Configs


### PR DESCRIPTION
- Adding SRIOV network configuration for dell server in tesla for reference for future use cases where a 5G core SRIOV network config is needed
- In this config all SRIOV networks for the 5G core are fully defined with VLAN and IPv4/IPv6 networks. 
- **TODO**: Decouple the IPv4/IPv6 configuration to the CNFs of the 5G Core network. Ideally, only the VLAN tag should be decided by the sysadmin and app should include the specific ip addressing. We leave it like that because it is what has been tested with the full config in SRIOV manifests. 
 